### PR TITLE
Chapter2 gometalinter fixes

### DIFF
--- a/chapter2/eight/eight.go
+++ b/chapter2/eight/eight.go
@@ -1,10 +1,14 @@
 package eight
 
+// Elem represents a node in a singly linked list.
 type Elem struct {
 	Value interface{}
 	next  *Elem
 }
 
+// DetectLoop returns a pointer to the element that causes the loop in the singly linked list.
+// Runtime is O(N) as it need to traverse the entire list.
+// Space is also O(N) to store seen nodes.
 func DetectLoop(head *Elem) *Elem {
 	seen := map[*Elem]struct{}{}
 	for head != nil {

--- a/chapter2/five/five.go
+++ b/chapter2/five/five.go
@@ -1,10 +1,14 @@
 package five
 
+// Elem represents a node in a singly linked list.
 type Elem struct {
 	Value int
 	next  *Elem
 }
 
+// SumReverseList takes two singly linked lists of ints.
+// It sums their values assuming the first value of each list is the 1's value.
+// And the 2nd value in each list is the 10's value and so on.
 func SumReverseList(first, second *Elem) int {
 	result := 0
 	carrytheone := false

--- a/chapter2/one/one.go
+++ b/chapter2/one/one.go
@@ -2,6 +2,7 @@ package one
 
 import "container/list"
 
+// RemoveDups removes duplicates from a linked list.
 func RemoveDups(l *list.List) {
 	m := map[int]int{}
 	for e := l.Front(); e != nil; e = e.Next() {

--- a/chapter2/seven/seven.go
+++ b/chapter2/seven/seven.go
@@ -1,10 +1,12 @@
 package seven
 
+// Elem represents a node in a singly linked list.
 type Elem struct {
 	Value int
 	next  *Elem
 }
 
+// Intersection returns a list that represents the common elements to both input lists.
 func Intersection(first, second *Elem) *Elem {
 	fl, sl := Length(first), Length(second)
 	if fl < sl {
@@ -26,6 +28,8 @@ func Intersection(first, second *Elem) *Elem {
 	return nil
 }
 
+// Length calculates the length of the singly linked list by traversing it.
+// This operation is runtime O(N).
 func Length(head *Elem) int {
 	result := 0
 	for ; head != nil; head = head.next {

--- a/chapter2/six/six.go
+++ b/chapter2/six/six.go
@@ -2,6 +2,7 @@ package six
 
 import "container/list"
 
+// IsPalindrome checks if a linked list is a palindrome.
 func IsPalindrome(head *list.List) bool {
 	front := head.Front()
 	back := head.Back()

--- a/chapter2/three/three.go
+++ b/chapter2/three/three.go
@@ -1,10 +1,13 @@
 package three
 
+// Elem represents a node in a singly linked list.
 type Elem struct {
 	Value interface{}
 	next  *Elem
 }
 
+// DeleteMiddle shifts all the elements of the singly linked list back one position.
+// Thereby deleting the value in the parameter elem.
 func DeleteMiddle(elem *Elem) {
 	for elem.next != nil {
 		elem.Value = elem.next.Value

--- a/chapter2/two/two.go
+++ b/chapter2/two/two.go
@@ -1,10 +1,13 @@
 package two
 
+// Elem represents a node in a singly linked list.
 type Elem struct {
 	Value interface{}
 	next  *Elem
 }
 
+// FindKth finds the k-th element from the end of the singly linked list.
+// This uses the ListSize function.
 func FindKth(head *Elem, k int) *Elem {
 	size := ListSize(head)
 	skip := size - k
@@ -14,6 +17,10 @@ func FindKth(head *Elem, k int) *Elem {
 	return head
 }
 
+// FindKth2Ptr finds the k-th element from the end of the singly linked list too.
+// However, it uses another pointer to run ahead k positions and then moves them both
+// in lock-step until the front pointer reaches the end. Then the following pointer
+// is pointing to the answer.
 func FindKth2Ptr(head *Elem, k int) *Elem {
 	ptr := head
 	for i := 0; i < k; i++ {
@@ -26,6 +33,8 @@ func FindKth2Ptr(head *Elem, k int) *Elem {
 	return ptr
 }
 
+// ListSize returns the size of the given singly linked list.
+// Runtime O(N) since it has to traverse the entire list.
 func ListSize(head *Elem) int {
 	count := 0
 	for head.next != nil {


### PR DESCRIPTION
Before this PR, `gometalinter` reported the following:
```
chapter2 git:(master) gometalinter ./...
eight/eight.go:3:6:warning: exported type Elem should have comment or be unexported (golint)
eight/eight.go:8:1:warning: exported function DetectLoop should have comment or be unexported (golint)
five/five.go:3:6:warning: exported type Elem should have comment or be unexported (golint)
five/five.go:8:1:warning: exported function SumReverseList should have comment or be unexported (golint)
one/one.go:5:1:warning: exported function RemoveDups should have comment or be unexported (golint)
seven/seven.go:3:6:warning: exported type Elem should have comment or be unexported (golint)
seven/seven.go:8:1:warning: exported function Intersection should have comment or be unexported (golint)
seven/seven.go:29:1:warning: exported function Length should have comment or be unexported (golint)
six/six.go:5:1:warning: exported function IsPalindrome should have comment or be unexported (golint)
three/three.go:3:6:warning: exported type Elem should have comment or be unexported (golint)
three/three.go:8:1:warning: exported function DeleteMiddle should have comment or be unexported (golint)
two/two.go:3:6:warning: exported type Elem should have comment or be unexported (golint)
two/two.go:8:1:warning: exported function FindKth should have comment or be unexported (golint)
two/two.go:17:1:warning: exported function FindKth2Ptr should have comment or be unexported (golint)
two/two.go:29:1:warning: exported function ListSize should have comment or be unexported (golint)
```
after this PR, `gometalinter` found nothing.