### PR TITLE
Chapter4 gometalinter fixes

### DIFF
--- a/chapter4/one/one.go
+++ b/chapter4/one/one.go
@@ -1,7 +1,9 @@
 package one
 
+// DiGraph represents a directed graph where each vertex is labeled by an integer.
 type DiGraph map[int]map[int]struct{}
 
+// RouteExists answers the question "Does a route exist between two given vertices?".
 func RouteExists(graph DiGraph, start, end int) bool {
 	var stack []int
 	discovered := make(map[int]struct{})

--- a/chapter4/two/two.go
+++ b/chapter4/two/two.go
@@ -1,10 +1,12 @@
 package two
 
+// Node represents a node in a binary tree.
 type Node struct {
 	Value       int
 	left, right *Node
 }
 
+// CreateBinaryTree builds a binary search tree given a sorted array of integers.
 func CreateBinaryTree(data []int, start, end int) *Node {
 	if start >= end {
 		return nil


### PR DESCRIPTION
```
gometalinter ./...
one/one.go:3:6:warning: exported type DiGraph should have comment or be unexported (golint)
one/one.go:5:1:warning: exported function RouteExists should have comment or be unexported (golint)
two/two.go:3:6:warning: exported type Node should have comment or be unexported (golint)
two/two.go:8:1:warning: exported function CreateBinaryTree should have comment or be unexported (golint)
```