### PR TITLE
Chapter10 gometalinter fixes

### DIFF
--- a/chapter10/five/five.go
+++ b/chapter10/five/five.go
@@ -1,5 +1,7 @@
 package five
 
+// SparseStringSearch does a binary search for a search value.
+// The data is expected to be sorted lexically (natural ordering).
 func SparseStringSearch(data []string, search string) int {
 	l, r := 0, len(data)-1
 	ll, lr := l, r

--- a/chapter10/five/five.go
+++ b/chapter10/five/five.go
@@ -12,9 +12,9 @@ func SparseStringSearch(data []string, search string) int {
 		} else if val == "" {
 			for ; data[mid] == ""; mid++ {
 			}
-			if val := data[mid]; val == search {
+			if nextval := data[mid]; nextval == search {
 				return mid
-			} else if search < val {
+			} else if search < nextval {
 				r = mid - 1
 			} else {
 				l = mid + 1

--- a/chapter10/four/four.go
+++ b/chapter10/four/four.go
@@ -15,7 +15,7 @@ func (ls *Listy) elementAt(i int) int {
 // The returned index is NOT zero-based.
 // -1 is returned if the search value does not exist in the list.
 func SearchListy(ls *Listy, search int) int {
-	index := 0
+	var index int
 	for index = 1; ls.elementAt(index) != -1; index *= 2 {
 	}
 	l, r := 1, index

--- a/chapter10/four/four.go
+++ b/chapter10/four/four.go
@@ -1,5 +1,6 @@
 package four
 
+// Listy is a slice of ints
 type Listy []int
 
 func (ls *Listy) elementAt(i int) int {
@@ -10,6 +11,9 @@ func (ls *Listy) elementAt(i int) int {
 	return d[i-1]
 }
 
+// SearchListy does a binary search to find the index of a search value.
+// The returned index is NOT zero-based.
+// -1 is returned if the search value does not exist in the list.
 func SearchListy(ls *Listy, search int) int {
 	index := 0
 	for index = 1; ls.elementAt(index) != -1; index *= 2 {

--- a/chapter10/one/one.go
+++ b/chapter10/one/one.go
@@ -1,5 +1,6 @@
 package one
 
+// Merge takes two sorted int slices and merges them into a new int slice.
 func Merge(a, b []int) []int {
 	result := make([]int, 0, len(a)+len(b))
 	i, j := 0, 0

--- a/chapter10/three/three.go
+++ b/chapter10/three/three.go
@@ -1,5 +1,7 @@
 package three
 
+// FindRotatedIndex returns the index of a search value in a sorted but rotated slice of ints.
+// The implementation uses a modified binary search that functions in a rotated slice of sorted ints.
 func FindRotatedIndex(data []int, search int) int {
 	l, r := 0, len(data)-1
 	for l <= r {

--- a/chapter10/two/two.go
+++ b/chapter10/two/two.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 )
 
+// GroupAnagrams sorts a slice of strings by grouping anagrams together.
 func GroupAnagrams(words []string) {
 	sort.SliceStable(words, func(i, j int) bool {
 		a := []rune(words[i])


### PR DESCRIPTION
```
gometalinter ./...
four/four.go:14:2:warning: ineffectual assignment to index (ineffassign)
five/five.go:3:1:warning: exported function SparseStringSearch should have comment or be unexported (golint)
four/four.go:3:6:warning: exported type Listy should have comment or be unexported (golint)
four/four.go:13:1:warning: exported function SearchListy should have comment or be unexported (golint)
one/one.go:3:1:warning: exported function Merge should have comment or be unexported (golint)
three/three.go:3:1:warning: exported function FindRotatedIndex should have comment or be unexported (golint)
two/two.go:7:1:warning: exported function GroupAnagrams should have comment or be unexported (golint)
five/five.go:13::warning: declaration of "val" shadows declaration at five/five.go:8 (vetshadow)
```