### PR TITLE
Chapter 11 gometalinter fixes

### DIFF
--- a/chapter11/one/one.go
+++ b/chapter11/one/one.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 )
 
+// Mistake demonstrates how to overflow a uint during a loop.
+// pass true to demonstrate the overflow and return an error.
+// pass false to not overflow and return nil instead of an error.
 func Mistake(overflow bool) error {
 	var i uint
 	var maxUint = ^uint(0) // get max uint for this architecture


### PR DESCRIPTION
```
gometalinter ./...
one/one.go:7:1:warning: exported function Mistake should have comment or be unexported (golint)
```